### PR TITLE
Fix bug: Remove Deprecated of lists to pluck

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -35,7 +35,7 @@ class Transaction extends Model
          where('pointable_id', $pointable->id)
          ->where('pointable_type', $pointable->getMorphClass())
          ->orderBy('created_at', 'desc')
-         ->lists('current')->first();
+         ->pluck('current')->first();
 
          if (!$currentPoint) {
            $currentPoint = 0.0;


### PR DESCRIPTION
In Laravel 5.3 the lists method on the Collection, query builder and Eloquent query builder objects has been renamed to pluck. The method signature remains the same.

Please merge this PR .